### PR TITLE
add skip csrf for api calls

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -8,7 +8,7 @@ class ApplicationController < ActionController::Base
                only: :index,
                unless: -> { :devise_controller? || :active_admin_controller? }
   # Prevent CSRF attacks by raising an exception.
-  protect_from_forgery with: :exception
+  protect_from_forgery with: :null_session
 
   def active_admin_controller?
     is_a?(ActiveAdmin::BaseController)


### PR DESCRIPTION
## Description:

skip csrf para las api request

Enlaces de interes:
https://openwebinars.net/blog/proteccion-csrf-en-mi-api-rest/
https://stackoverflow.com/questions/1177863/how-do-i-ignore-the-authenticity-token-for-specific-actions-in-rails

---

#### Notes:

---

## As the author of this PR, I have (mark with an 'x'):

- [x] Tested my proposed changes and verified that there were no server errors or UI bugs
- [x] Assigned one or more
- [ ] Included any new migration files

