### PR TITLE
add verify_auth_token if is json request

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -8,7 +8,12 @@ class ApplicationController < ActionController::Base
                only: :index,
                unless: -> { :devise_controller? || :active_admin_controller? }
   # Prevent CSRF attacks by raising an exception.
-  protect_from_forgery with: :null_session
+  # protect_from_forgery with: :exception
+  skip_before_action :verify_authenticity_token, if: :json_request?
+
+  def json_request?
+    request.format.json?
+  end
 
   def active_admin_controller?
     is_a?(ActiveAdmin::BaseController)


### PR DESCRIPTION
## Description:

Skip csrf verificacion si el body de la request es json y se mantiene para las acciones de active admin.

---

#### Notes:

---

## As the author of this PR, I have (mark with an 'x'):

- [x] Tested my proposed changes and verified that there were no server errors or UI bugs
- [x] Assigned one or more
- [ ] Included any new migration files

