### PR TITLE
fix duplicated person-projects

### DIFF
--- a/app/controllers/api/v1/person_project_controller.rb
+++ b/app/controllers/api/v1/person_project_controller.rb
@@ -8,8 +8,7 @@ module Api
       end
 
       def index
-        # FIXME: Arreglar 'eager loading detected' para person_project
-        @people = Person.includes(:projects).references(:projects).group('projects.id', 'people.id')
+        @people = Person.includes(:projects, :person_project)
       end
 
       def show

--- a/app/views/api/v1/person_project/index.json.jbuilder
+++ b/app/views/api/v1/person_project/index.json.jbuilder
@@ -4,7 +4,7 @@ json.person_project do
       json.partial! 'api/v1/people/short_info', person: person
       json.projects person.projects do |project|
         json.partial! 'api/v1/projects/short_info', project: project
-        json.dates project.person_project do |person_project|
+        json.dates project.person_project.where(person_id: person) do |person_project|
           json.partial! 'dates', date: person_project
         end
       end


### PR DESCRIPTION
## Description:

Se arregla `where` para obtener los person_project asociados al proyecto y la persona

---

#### Notes:


---

## As the author of this PR, I have (mark with an 'x'):

- [ ] ¿Puedes entender el cambio facilmente?
- [ ] ¿Parece que cumple con el requerimiento?
- [ ] ¿Las pruebas cubren suficientes casos?
- [ ] ¿Se consideran la mayoría de los casos y flujos?
- [ ] ¿Es necesario todo el código y los comentarios?
- [ ] ¿Las nuevas dependencias son seguras y fiables? ¿Son verdaderamente necesarias?
- [ ] ¿Se actualizaron los documentos relevantes?
- [ ] ¿Los endpoints contienen controles de autenticación y autorización?
- [ ] ¿Incluye nuevas migraciones?

